### PR TITLE
Adds PHP 7.2 to the CI matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
 
 install:
   - composer install


### PR DESCRIPTION
From https://github.com/jcchavezs/httptest-php/pull/6#issuecomment-387541463:
> I can't get this to work in PHP 7.2 although it seems to work for PHP 7.1. The exit doesn't seem to kill the process. If I change the exit to posix_kill(posix_getpid(), SIGTERM) but that adds another required extension.

and from https://github.com/jcchavezs/httptest-php/pull/6#issuecomment-387560387:
> Hmm, it does seem to be working on most PHP 7.2 installs. It fails on one of my PHP 7.2 installs. Looks like it fails if I have grpc enabled - most likely a bug with grpc, not this library.

This PR adds 7.2, if it does not fail we might need to improve tests.

Ping @chingor13